### PR TITLE
Do not record idempotent requests if invalid, unauthorized, or not_found

### DIFF
--- a/app/controllers/concerns/api/idempotentable.rb
+++ b/app/controllers/concerns/api/idempotentable.rb
@@ -29,13 +29,13 @@ module API
     end
 
     def idempotency_record_request!
-      return if response.status == 401 # Return when unauthorized.
+      return if [400, 401, 404].include?(response.status) # Do not record if invalid, unauthorized, not_found
 
-      response_body =   if response.body.is_a?(String)
-                          JSON.parse(response.body)
-                        else
-                          response.body
-                        end
+      response_body = if response.body.is_a?(String)
+                        JSON.parse(response.body)
+                      else
+                        response.body
+                      end
 
       IdempotencyKey.create!(
         key: idempotency_key_header,


### PR DESCRIPTION
Fix #24 

@mattgmarcus Let me know if you think this matches expectations.  I chose to be explicit about what codes to ignore.  I don't believe we throw any other `4XX` response code, so as it stands all others (`2XX`, `5XX`, etc.) will be recorded.