### PR TITLE
Fix bug in warden code

### DIFF
--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -24,7 +24,7 @@ Warden::Strategies.add(:developer) do
   end
 
   def authenticate!
-    success!(User.first || FactoryBot.create(:user, :admin))
+    success!(User.where(is_admin: true).first || FactoryBot.create(:user, :admin))
   end
 end
 


### PR DESCRIPTION
It would find the first user, regardless of if they were an admin, when doing the dev log in